### PR TITLE
explicitly pass vars to build amdsec

### DIFF
--- a/mets_dnx/factory.py
+++ b/mets_dnx/factory.py
@@ -142,10 +142,10 @@ def _build_ie_dmd_amd(mets,
     ie_amd_source = None
     build_amdsec(
             ie_amdsec,
-            ie_amd_tech,
-            ie_amd_rights,
-            ie_amd_digiprov,
-            ie_amd_source)
+            tech_sec=ie_amd_tech,
+            rights_sec=ie_amd_rights,
+            digiprov_sec=ie_amd_digiprov,
+            source_sec=ie_amd_source)
 
 def build_mets(ie_dmd_dict=None,
                 pres_master_dir=None,

--- a/mets_dnx/factory.py
+++ b/mets_dnx/factory.py
@@ -26,78 +26,72 @@ def generate_md5(filepath, block_size=2**20):
     return m.hexdigest()
 
 
-def build_amdsec(amdsec, tech_sec=None, rights_sec=None,
-                 source_sec=None, digiprov_sec=None):
-    amd_id = amdsec.attrib['ID']
+def build_amdsec(
+    amdsec, tech_sec=None, rights_sec=None, source_sec=None, digiprov_sec=None
+):
+    amd_id = amdsec.attrib["ID"]
     amd_tech = ET.SubElement(
-                    amdsec,
-                    "{http://www.loc.gov/METS/}techMD",
-                    ID=amd_id + "-tech")
+        amdsec, "{http://www.loc.gov/METS/}techMD", ID=amd_id + "-tech"
+    )
     amd_rights = ET.SubElement(
-                    amdsec,
-                    "{http://www.loc.gov/METS/}rightsMD",
-                    ID=amd_id + "-rights")
+        amdsec, "{http://www.loc.gov/METS/}rightsMD", ID=amd_id + "-rights"
+    )
     if source_sec != None:
         amd_source = ET.SubElement(
-                        amdsec,
-                        "{http://www.loc.gov/METS/}sourceMD",
-                        ID=amd_id + "-source")
+            amdsec, "{http://www.loc.gov/METS/}sourceMD", ID=amd_id + "-source"
+        )
     amd_digiprov = ET.SubElement(
-                    amdsec,
-                    "{http://www.loc.gov/METS/}digiprovMD",
-                    ID=amd_id + "-digiprov")
-    
+        amdsec, "{http://www.loc.gov/METS/}digiprovMD", ID=amd_id + "-digiprov"
+    )
+
     if source_sec == None:
         el_list = [amd_tech, amd_rights, amd_digiprov]
     else:
         el_list = [amd_tech, amd_rights, amd_source, amd_digiprov]
     for el in el_list:
         mdWrap = ET.SubElement(
-                        el,
-                        "{http://www.loc.gov/METS/}mdWrap",
-                        MDTYPE="OTHER", OTHERMDTYPE="dnx")
+            el, "{http://www.loc.gov/METS/}mdWrap", MDTYPE="OTHER", OTHERMDTYPE="dnx"
+        )
         xmlData = ET.SubElement(mdWrap, "{http://www.loc.gov/METS/}xmlData")
-        if (el.tag == "{http://www.loc.gov/METS/}techMD" and
-                tech_sec != None):
+        if el.tag == "{http://www.loc.gov/METS/}techMD" and tech_sec != None:
             xmlData.append(tech_sec)
-        elif (el.tag == "{http://www.loc.gov/METS/}techMD" and
-                tech_sec == None):
-            xmlData.append(ET.Element("dnx",
-                xmlns="http://www.exlibrisgroup.com/dps/dnx"))
+        elif el.tag == "{http://www.loc.gov/METS/}techMD" and tech_sec == None:
+            xmlData.append(
+                ET.Element("dnx", xmlns="http://www.exlibrisgroup.com/dps/dnx")
+            )
 
-        if (el.tag == "{http://www.loc.gov/METS/}rightsMD" and
-                rights_sec != None):
+        if el.tag == "{http://www.loc.gov/METS/}rightsMD" and rights_sec != None:
             xmlData.append(rights_sec)
-        elif (el.tag == "{http://www.loc.gov/METS/}rightsMD" and
-                rights_sec == None):
-            xmlData.append(ET.Element("dnx",
-                xmlns="http://www.exlibrisgroup.com/dps/dnx"))
+        elif el.tag == "{http://www.loc.gov/METS/}rightsMD" and rights_sec == None:
+            xmlData.append(
+                ET.Element("dnx", xmlns="http://www.exlibrisgroup.com/dps/dnx")
+            )
 
-        if (el.tag == "{http://www.loc.gov/METS/}sourceMD" and
-                source_sec != None):
+        if el.tag == "{http://www.loc.gov/METS/}sourceMD" and source_sec != None:
             xmlData.append(source_sec)
         # elif (el.tag == "{http://www.loc.gov/METS/}sourceMD" and
         #         source_sec == None):
         #     xmlData.append(ET.Element("dnx",
         #         xmlns="http://www.exlibrisgroup.com/dps/dnx"))
 
-        if (el.tag == "{http://www.loc.gov/METS/}digiprovMD" and
-                digiprov_sec != None):
+        if el.tag == "{http://www.loc.gov/METS/}digiprovMD" and digiprov_sec != None:
             xmlData.append(digiprov_sec)
-        elif (el.tag == "{http://www.loc.gov/METS/}digiprovMD" and
-                digiprov_sec == None):
-            xmlData.append(ET.Element("dnx",
-                xmlns="http://www.exlibrisgroup.com/dps/dnx"))
+        elif el.tag == "{http://www.loc.gov/METS/}digiprovMD" and digiprov_sec == None:
+            xmlData.append(
+                ET.Element("dnx", xmlns="http://www.exlibrisgroup.com/dps/dnx")
+            )
 
 
-def _build_ie_dmd_amd(mets,
-                   ie_dmd_dict=None,
-                   generalIECharacteristics=None,
-                   cms=None,
-                   webHarvesting=None,
-                   objectIdentifier=None,
-                   accessRightsPolicy=None,
-                   eventList=None):
+def _build_ie_dmd_amd(
+    mets,
+    ie_dmd_dict=None,
+    generalIECharacteristics=None,
+    cms=None,
+    webHarvesting=None,
+    objectIdentifier=None,
+    accessRightsPolicy=None,
+    eventList=None,
+):
     # first off, build ie-dmdsec
     # check if ie_dmd_dict is a single dictionary inside a list
     # (which is the convention for the METS factory, but not necessary for
@@ -105,78 +99,77 @@ def _build_ie_dmd_amd(mets,
     if type(ie_dmd_dict) == list and len(ie_dmd_dict) == 1:
         ie_dmd_dict = ie_dmd_dict[0]
     dc_record = dc_factory.build_dc_record(ie_dmd_dict)
-    dmdsec = ET.SubElement(
-                mets,
-                "{http://www.loc.gov/METS/}dmdSec",
-                ID="ie-dmd")
-    mdwrap = ET.SubElement(
-                dmdsec,
-                "{http://www.loc.gov/METS/}mdWrap",
-                MDTYPE="DC")
-    xmldata = ET.SubElement(
-                mdwrap,
-                "{http://www.loc.gov/METS/}xmlData")
+    dmdsec = ET.SubElement(mets, "{http://www.loc.gov/METS/}dmdSec", ID="ie-dmd")
+    mdwrap = ET.SubElement(dmdsec, "{http://www.loc.gov/METS/}mdWrap", MDTYPE="DC")
+    xmldata = ET.SubElement(mdwrap, "{http://www.loc.gov/METS/}xmlData")
     xmldata.append(dc_record)
 
     # build ie amd section
-    ie_amdsec = ET.SubElement(
-                    mets,
-                    "{http://www.loc.gov/METS/}amdSec",
-                    ID="ie-amd")
-    if ((generalIECharacteristics != None)
-            or (cms != None)
-            or (objectIdentifier != None)
-            or (webHarvesting != None)):
+    ie_amdsec = ET.SubElement(mets, "{http://www.loc.gov/METS/}amdSec", ID="ie-amd")
+    if (
+        (generalIECharacteristics != None)
+        or (cms != None)
+        or (objectIdentifier != None)
+        or (webHarvesting != None)
+    ):
         ie_amd_tech = dnx_factory.build_ie_amdTech(
             generalIECharacteristics=generalIECharacteristics,
             objectIdentifier=objectIdentifier,
             CMS=cms,
-            webHarvesting=webHarvesting)
+            webHarvesting=webHarvesting,
+        )
     else:
         ie_amd_tech = None
-    if (accessRightsPolicy != None):
+    if accessRightsPolicy != None:
         ie_amd_rights = dnx_factory.build_ie_amdRights(
-            accessRightsPolicy=accessRightsPolicy)
+            accessRightsPolicy=accessRightsPolicy
+        )
     else:
         ie_amd_rights = None
-    if (eventList != None):
+    if eventList != None:
         ie_amd_digiprov = dnx_factory.build_ie_amdDigiprov(event=eventList)
     else:
         ie_amd_digiprov = None
     # TODO (2016-10-03): add functionality for ie_amdSourceMD
     ie_amd_source = None
     build_amdsec(
-            ie_amdsec,
-            tech_sec=ie_amd_tech,
-            rights_sec=ie_amd_rights,
-            digiprov_sec=ie_amd_digiprov,
-            source_sec=ie_amd_source)
+        ie_amdsec,
+        tech_sec=ie_amd_tech,
+        rights_sec=ie_amd_rights,
+        digiprov_sec=ie_amd_digiprov,
+        source_sec=ie_amd_source,
+    )
 
-def build_mets(ie_dmd_dict=None,
-                pres_master_dir=None,
-                modified_master_dir=None,
-                access_derivative_dir=None,
-                cms=None,
-                webHarvesting=None,
-                generalIECharacteristics=None,
-                objectIdentifier=None,
-                accessRightsPolicy=None,
-                eventList=None,
-                input_dir=None,
-                digital_original=False,
-                structmap_type='DEFAULT', 
-                exclude_file_characteristics = []):
+
+def build_mets(
+    ie_dmd_dict=None,
+    pres_master_dir=None,
+    modified_master_dir=None,
+    access_derivative_dir=None,
+    cms=None,
+    webHarvesting=None,
+    generalIECharacteristics=None,
+    objectIdentifier=None,
+    accessRightsPolicy=None,
+    eventList=None,
+    input_dir=None,
+    digital_original=False,
+    structmap_type="DEFAULT",
+    exclude_file_characteristics=[],
+):
 
     mets = mf.build_mets()
 
-    _build_ie_dmd_amd(mets,
-            ie_dmd_dict=ie_dmd_dict,
-            generalIECharacteristics=generalIECharacteristics,
-            cms=cms,
-            webHarvesting=webHarvesting,
-            objectIdentifier=objectIdentifier,
-            accessRightsPolicy=accessRightsPolicy,
-            eventList=eventList)
+    _build_ie_dmd_amd(
+        mets,
+        ie_dmd_dict=ie_dmd_dict,
+        generalIECharacteristics=generalIECharacteristics,
+        cms=cms,
+        webHarvesting=webHarvesting,
+        objectIdentifier=objectIdentifier,
+        accessRightsPolicy=accessRightsPolicy,
+        eventList=eventList,
+    )
 
     mf.build_amdsec_filegrp_structmap(
         mets,
@@ -185,39 +178,45 @@ def build_mets(ie_dmd_dict=None,
         modified_master_dir=modified_master_dir,
         access_derivative_dir=access_derivative_dir,
         digital_original=digital_original,
-        input_dir=input_dir)
-
+        input_dir=input_dir,
+    )
 
     # Create representation_level and file_level amdsecs, based on
     # the filegrp details
-    file_groups = mets.findall('.//{http://www.loc.gov/METS/}fileGrp')
+    file_groups = mets.findall(".//{http://www.loc.gov/METS/}fileGrp")
     for file_group in file_groups:
-        rep_id = file_group.attrib['ID']
-        rep_type = mets.find('.//{%s}structMap[@ID="%s-1"]/{%s}div' %
-            ('http://www.loc.gov/METS/', rep_id, 'http://www.loc.gov/METS/')
-            ).attrib['LABEL']
+        rep_id = file_group.attrib["ID"]
+        rep_type = mets.find(
+            './/{%s}structMap[@ID="%s-1"]/{%s}div'
+            % ("http://www.loc.gov/METS/", rep_id, "http://www.loc.gov/METS/")
+        ).attrib["LABEL"]
 
-        if rep_type == 'Preservation Master':
-            pres_type = 'PRESERVATION_MASTER'
+        if rep_type == "Preservation Master":
+            pres_type = "PRESERVATION_MASTER"
             pres_location = pres_master_dir
-        elif rep_type == 'Modified Master':
-            pres_type = 'MODIFIED_MASTER'
+        elif rep_type == "Modified Master":
+            pres_type = "MODIFIED_MASTER"
             pres_location = modified_master_dir
-        elif rep_type == 'Derivative Copy':
+        elif rep_type == "Derivative Copy":
             pres_location = access_derivative_dir
-            pres_type = 'DERIVATIVE_COPY'
+            pres_type = "DERIVATIVE_COPY"
         else:
             pres_type = None
-            pres_location = '.'
+            pres_location = "."
 
-        rep_amdsec = mets.xpath("//mets:amdSec[@ID='%s']" %
-                str(rep_id + '-amd'), namespaces=mets.nsmap)[0]
-        general_rep_characteristics = [{#'RevisionNumber': '1',
-                'DigitalOriginal': str(digital_original).lower(),
-                'usageType': 'VIEW',
-                'preservationType': pres_type}]
+        rep_amdsec = mets.xpath(
+            "//mets:amdSec[@ID='%s']" % str(rep_id + "-amd"), namespaces=mets.nsmap
+        )[0]
+        general_rep_characteristics = [
+            {  #'RevisionNumber': '1',
+                "DigitalOriginal": str(digital_original).lower(),
+                "usageType": "VIEW",
+                "preservationType": pres_type,
+            }
+        ]
         rep_amd_tech = dnx_factory.build_rep_amdTech(
-            generalRepCharacteristics=general_rep_characteristics)
+            generalRepCharacteristics=general_rep_characteristics
+        )
         rep_amd_rights = None
         rep_amd_digiprov = None
         rep_amd_source = None
@@ -226,98 +225,113 @@ def build_mets(ie_dmd_dict=None,
             tech_sec=rep_amd_tech,
             rights_sec=rep_amd_rights,
             source_sec=rep_amd_source,
-            digiprov_sec=rep_amd_digiprov)
+            digiprov_sec=rep_amd_digiprov,
+        )
 
         # create amdsec for files
-        for fl in file_group.findall('./{http://www.loc.gov/METS/}file'):
-            fl_id = fl.attrib['ID']
+        for fl in file_group.findall("./{http://www.loc.gov/METS/}file"):
+            fl_id = fl.attrib["ID"]
             fl_amdsec = None
-            fl_amdsec = mets.xpath("//mets:amdSec[@ID='%s']" %
-                    str(fl_id + '-amd'), namespaces=mets.nsmap)[0]
-            file_original_location = os.path.join(input_dir,
-                fl.find('./{http://www.loc.gov/METS/}FLocat').attrib[
-                        '{http://www.w3.org/1999/xlink}href'])
-            file_original_name = os.path.normpath(file_original_location).split(os.path.sep)[-1]
+            fl_amdsec = mets.xpath(
+                "//mets:amdSec[@ID='%s']" % str(fl_id + "-amd"), namespaces=mets.nsmap
+            )[0]
+            file_original_location = os.path.join(
+                input_dir,
+                fl.find("./{http://www.loc.gov/METS/}FLocat").attrib[
+                    "{http://www.w3.org/1999/xlink}href"
+                ],
+            )
+            file_original_name = os.path.normpath(file_original_location).split(
+                os.path.sep
+            )[-1]
             file_label = os.path.splitext(file_original_name)[0]
             file_size_bytes = os.path.getsize(file_original_location)
             last_modified = time.strftime(
-                    "%Y-%m-%dT%H:%M:%S",
-                    time.localtime(os.path.getmtime(file_original_location)))
+                "%Y-%m-%dT%H:%M:%S",
+                time.localtime(os.path.getmtime(file_original_location)),
+            )
             created_time = time.strftime(
-                    "%Y-%m-%dT%H:%M:%S",
-                    time.localtime(os.path.getctime(file_original_location)))
-            general_file_characteristics = [{
-                # 'fileOriginalPath': file_original_location,
-                'fileSizeBytes': str(file_size_bytes),
-                # 'fileModificationDate': last_modified,
-                # 'fileCreationDate': created_time,
-                'fileOriginalName': file_original_name,
-                'label': file_label,
-                'fileMIMEType': "text/plain",}]
-            if exclude_file_characteristics!=[]:
+                "%Y-%m-%dT%H:%M:%S",
+                time.localtime(os.path.getctime(file_original_location)),
+            )
+            general_file_characteristics = [
+                {
+                    # 'fileOriginalPath': file_original_location,
+                    "fileSizeBytes": str(file_size_bytes),
+                    "fileModificationDate": last_modified,
+                    "fileCreationDate": created_time,
+                    "fileOriginalName": file_original_name,
+                    "label": file_label,
+                    "fileMIMEType": "text/plain",
+                }
+            ]
+            if exclude_file_characteristics != []:
                 for file_characteristics in exclude_file_characteristics:
                     if file_characteristics in general_file_characteristics[0].keys():
                         general_file_characteristics[0].pop(file_characteristics)
 
-            file_fixity =  [{
-                'fixityType': 'MD5',
-                'fixityValue': generate_md5(file_original_location)}]
+            file_fixity = [
+                {
+                    "fixityType": "MD5",
+                    "fixityValue": generate_md5(file_original_location),
+                }
+            ]
 
             fl_amd_tech = dnx_factory.build_file_amdTech(
                 generalFileCharacteristics=general_file_characteristics,
-                fileFixity=file_fixity)
+                fileFixity=file_fixity,
+            )
             build_amdsec(fl_amdsec, tech_sec=fl_amd_tech)
-
 
     # clean up identifiers so they are consistent with Rosetta requirements
     for element in mets.xpath(".//*[@ID]"):
-        element.attrib['ID'] = re.sub('ie[0-9]+\-', '', element.attrib['ID'])
-        element.attrib['ID'] = re.sub(
-                'rep([0-9]+)\-file([0-9]+)',
-                r'fid\2-\1',
-                element.attrib['ID'])
+        element.attrib["ID"] = re.sub("ie[0-9]+\-", "", element.attrib["ID"])
+        element.attrib["ID"] = re.sub(
+            "rep([0-9]+)\-file([0-9]+)", r"fid\2-\1", element.attrib["ID"]
+        )
     for element in mets.xpath(".//*[@ADMID]"):
-        element.attrib['ADMID'] = re.sub(
-                'ie[0-9]+\-rep([0-9]+)\-file([0-9]+)-amd',
-                r'fid\2-\1-amd',
-                element.attrib['ADMID'])
-        element.attrib['ADMID'] = re.sub(
-                'ie[0-9]+\-rep([0-9]+)-amd',
-                r'rep\1-amd',
-                element.attrib['ADMID'])
+        element.attrib["ADMID"] = re.sub(
+            "ie[0-9]+\-rep([0-9]+)\-file([0-9]+)-amd",
+            r"fid\2-\1-amd",
+            element.attrib["ADMID"],
+        )
+        element.attrib["ADMID"] = re.sub(
+            "ie[0-9]+\-rep([0-9]+)-amd", r"rep\1-amd", element.attrib["ADMID"]
+        )
     for element in mets.xpath(".//*[@FILEID]"):
-        element.attrib['FILEID'] = re.sub(
-                'ie[0-9]+\-rep([0-9])+\-file([0-9]+)',
-                r'fid\2-\1',
-                element.attrib['FILEID'])
+        element.attrib["FILEID"] = re.sub(
+            "ie[0-9]+\-rep([0-9])+\-file([0-9]+)", r"fid\2-\1", element.attrib["FILEID"]
+        )
 
     # 2017-02-16 (SM): Modify the file label in the structmaps so that it does
     # not contain file extensions. This is an NDHA requirement, so I am
     # reluctant to put this on the actual METS factory level.
     # 2017-02-16 (SM): Add an order count to the divs in the structmap.
-    struct_maps = mets.findall('./{http://www.loc.gov/METS/}structMap')
+    struct_maps = mets.findall("./{http://www.loc.gov/METS/}structMap")
     for struct_map in struct_maps:
         top_div_count = 0
-        top_divs = struct_map.findall('./{http://www.loc.gov/METS/}div')
+        top_divs = struct_map.findall("./{http://www.loc.gov/METS/}div")
         for top_div in top_divs:
             top_div_count += 1
             # top_div.attrib['ORDER'] = str(top_div_count)
-             # Insert "Table of Contents" div between the file divs and the top div
-            toc_element = ET.Element('{http://www.loc.gov/METS/}div')
-            toc_element.attrib['LABEL'] = 'Table of Contents'
+            # Insert "Table of Contents" div between the file divs and the top div
+            toc_element = ET.Element("{http://www.loc.gov/METS/}div")
+            toc_element.attrib["LABEL"] = "Table of Contents"
 
             # lower_div_count = 0
-            file_divs = top_div.findall('./{http://www.loc.gov/METS/}div')
+            file_divs = top_div.findall("./{http://www.loc.gov/METS/}div")
             top_div.insert(0, toc_element)
             for file_div in file_divs:
-            #     lower_div_count += 1
-            #     # 2017-07-20: Removing "ORDER" attribute
-            #     # file_div.attrib['ORDER'] = str(lower_div_count)
+                #     lower_div_count += 1
+                #     # 2017-07-20: Removing "ORDER" attribute
+                #     # file_div.attrib['ORDER'] = str(lower_div_count)
                 # file_div.attrib["LABEL"] = os.path.splitext(file_div.attrib["LABEL"])[0]
-            #     # 2017-07-19: commented out line below, not sure why it was there in the first place!
-            #     # del file_div.attrib['TYPE']
+                #     # 2017-07-19: commented out line below, not sure why it was there in the first place!
+                #     # del file_div.attrib['TYPE']
                 toc_element.append(file_div)
-            file_divs = top_div.findall('.//{http://www.loc.gov/METS/}div[@TYPE="FILE"]')
+            file_divs = top_div.findall(
+                './/{http://www.loc.gov/METS/}div[@TYPE="FILE"]'
+            )
             for file_div in file_divs:
                 file_div.attrib["LABEL"] = os.path.splitext(file_div.attrib["LABEL"])[0]
 
@@ -325,34 +339,43 @@ def build_mets(ie_dmd_dict=None,
     return mets
 
 
-def build_single_file_mets(ie_dmd_dict=None,
-                filepath=None,
-                cms=None,
-                webHarvesting=None,
-                generalIECharacteristics=None,
-                objectIdentifier=None,
-                accessRightsPolicy=None,
-                eventList=None,
-                digital_original=False,
-                exclude_file_characteristics = []):
+def build_single_file_mets(
+    ie_dmd_dict=None,
+    filepath=None,
+    cms=None,
+    webHarvesting=None,
+    generalIECharacteristics=None,
+    objectIdentifier=None,
+    accessRightsPolicy=None,
+    eventList=None,
+    digital_original=False,
+    exclude_file_characteristics=[],
+):
     mets = mf.build_mets()
-    _build_ie_dmd_amd(mets,
-            ie_dmd_dict=ie_dmd_dict,
-            generalIECharacteristics=generalIECharacteristics,
-            cms=cms,
-            webHarvesting=webHarvesting,
-            objectIdentifier=objectIdentifier,
-            accessRightsPolicy=accessRightsPolicy,
-            eventList=eventList)
+    _build_ie_dmd_amd(
+        mets,
+        ie_dmd_dict=ie_dmd_dict,
+        generalIECharacteristics=generalIECharacteristics,
+        cms=cms,
+        webHarvesting=webHarvesting,
+        objectIdentifier=objectIdentifier,
+        accessRightsPolicy=accessRightsPolicy,
+        eventList=eventList,
+    )
 
     # Build rep amdsec
     rep_amdsec = ET.Element("{http://www.loc.gov/METS/}amdSec", ID="rep1-amd")
-    general_rep_characteristics = [{'RevisionNumber': '1',
-            'DigitalOriginal': str(digital_original).lower(),
-            'usageType': 'VIEW',
-            'preservationType': 'PRESERVATION_MASTER'}]
+    general_rep_characteristics = [
+        {
+            "RevisionNumber": "1",
+            "DigitalOriginal": str(digital_original).lower(),
+            "usageType": "VIEW",
+            "preservationType": "PRESERVATION_MASTER",
+        }
+    ]
     rep_amd_tech = dnx_factory.build_rep_amdTech(
-        generalRepCharacteristics=general_rep_characteristics)
+        generalRepCharacteristics=general_rep_characteristics
+    )
     rep_amd_rights = None
     rep_amd_digiprov = None
     rep_amd_source = None
@@ -361,7 +384,8 @@ def build_single_file_mets(ie_dmd_dict=None,
         tech_sec=rep_amd_tech,
         rights_sec=rep_amd_rights,
         source_sec=rep_amd_source,
-        digiprov_sec=rep_amd_digiprov)
+        digiprov_sec=rep_amd_digiprov,
+    )
     mets.append(rep_amdsec)
 
     # Build file amdsec
@@ -371,29 +395,32 @@ def build_single_file_mets(ie_dmd_dict=None,
     file_label = os.path.splitext(file_original_name)[0]
     file_size_bytes = os.path.getsize(file_original_location)
     last_modified = time.strftime(
-            "%Y-%m-%dT%H:%M:%S",
-            time.localtime(os.path.getmtime(file_original_location)))
+        "%Y-%m-%dT%H:%M:%S", time.localtime(os.path.getmtime(file_original_location))
+    )
     created_time = time.strftime(
-            "%Y-%m-%dT%H:%M:%S",
-            time.localtime(os.path.getctime(file_original_location)))
-    general_file_characteristics = [{
-        'fileOriginalPath': file_original_location,
-        'fileSizeBytes': str(file_size_bytes),
-        'fileModificationDate': last_modified,
-        'fileCreationDate': created_time,
-        'fileOriginalName': file_original_name,
-        'label': file_label}]
-    if exclude_file_characteristics!=[]:
+        "%Y-%m-%dT%H:%M:%S", time.localtime(os.path.getctime(file_original_location))
+    )
+    general_file_characteristics = [
+        {
+            "fileOriginalPath": file_original_location,
+            "fileSizeBytes": str(file_size_bytes),
+            "fileModificationDate": last_modified,
+            "fileCreationDate": created_time,
+            "fileOriginalName": file_original_name,
+            "label": file_label,
+        }
+    ]
+    if exclude_file_characteristics != []:
         for file_characteristics in exclude_file_characteristics:
             if file_characteristics in general_file_characteristics[0].keys():
                 general_file_characteristics[0].pop(file_characteristics)
-    file_fixity =  [{
-        'fixityType': 'MD5',
-        'fixityValue': generate_md5(file_original_location)}]
+    file_fixity = [
+        {"fixityType": "MD5", "fixityValue": generate_md5(file_original_location)}
+    ]
 
     fl_amd_tech = dnx_factory.build_file_amdTech(
-        generalFileCharacteristics=general_file_characteristics,
-        fileFixity=file_fixity)
+        generalFileCharacteristics=general_file_characteristics, fileFixity=file_fixity
+    )
     build_amdsec(fl_amdsec, tech_sec=fl_amd_tech)
     mets.append(fl_amdsec)
 
@@ -404,7 +431,7 @@ def build_single_file_mets(ie_dmd_dict=None,
     filegrp = mm.FileGrp(ID="rep1", ADMID="rep1-amd", USE="VIEW")
     filesec.append(filegrp)
 
-    file_el = mm.File(ID='fid1-1', ADMID="fid1-1-amd")
+    file_el = mm.File(ID="fid1-1", ADMID="fid1-1-amd")
     filegrp.append(file_el)
 
     flocat = mm.FLocat(LOCTYPE="URL", href=filename)
@@ -424,7 +451,7 @@ def build_single_file_mets(ie_dmd_dict=None,
     div_3 = mm.Div(LABEL=file_label, TYPE="FILE")
     div_2.append(div_3)
 
-    fptr = mm.Fptr(FILEID='fid1-1')
+    fptr = mm.Fptr(FILEID="fid1-1")
     div_3.append(fptr)
 
     mets.append(structmap)
@@ -442,30 +469,30 @@ def _build_fl_amd_from_json(mets, file_no, rep_no, item):
     note = None
     # events = None
 
-    gfc = {} # general file characteristics
+    gfc = {}  # general file characteristics
     fixity = {}
     events = {}
-    gfc['fileOriginalPath'] = item['fileOriginalPath']
+    gfc["fileOriginalPath"] = item["fileOriginalPath"]
     for key in item.keys():
-        if key == 'fileOriginalName':
-            gfc['fileOriginalName'] = item[key]
-        if key == 'fileSizeBytes':
-            gfc['fileSizeBytes'] = item[key]
-        if key == 'fileCreationDate':
-            gfc['fileCreationDate'] = item[key]
-        if key == 'fileModificationDate':
-            gfc['fileModificationDate'] = item[key]
-        if key == 'note':
-            gfc['note'] = item[key]
-        if key == 'label':
-            gfc['label'] = item[key]
+        if key == "fileOriginalName":
+            gfc["fileOriginalName"] = item[key]
+        if key == "fileSizeBytes":
+            gfc["fileSizeBytes"] = item[key]
+        if key == "fileCreationDate":
+            gfc["fileCreationDate"] = item[key]
+        if key == "fileModificationDate":
+            gfc["fileModificationDate"] = item[key]
+        if key == "note":
+            gfc["note"] = item[key]
+        if key == "label":
+            gfc["label"] = item[key]
 
         # fixity values
-        if key.upper() == 'MD5':
-            fixity['fixityType'] = 'MD5'
-            fixity['fixityValue'] = item[key]
+        if key.upper() == "MD5":
+            fixity["fixityType"] = "MD5"
+            fixity["fixityValue"] = item[key]
         # provenance values
-        if key == 'events':
+        if key == "events":
             events = item[key]
 
     # Check the supplied fixity to make sure it can be reproduced
@@ -487,10 +514,9 @@ def _build_fl_amd_from_json(mets, file_no, rep_no, item):
         events = None
 
     fl_amd_tech = dnx_factory.build_file_amdTech(
-        generalFileCharacteristics=[gfc],
-        fileFixity=[fixity])
-    fl_amd_digiprov = dnx_factory.build_ie_amdDigiprov(
-        event=events)
+        generalFileCharacteristics=[gfc], fileFixity=[fixity]
+    )
+    fl_amd_digiprov = dnx_factory.build_ie_amdDigiprov(event=events)
     # yes, the call to ie amdDigiprov is intentional,
     # as we don't yet have a file digiprov builder. Should be fine though.
 
@@ -517,9 +543,13 @@ def _parse_json_for_filegrp(filegrp, rep_no, json_doc, input_dir):
     file_no = 1
     for item in rep_dict:
         try:
-            file_el = mm.File(ID="fid{}-{}".format(file_no, rep_no),
-                              ADMID="fid{}-{}-amd".format(file_no, rep_no))
-            flocat = mm.FLocat(LOCTYPE="URL", href=item['fileOriginalPath'].replace('\\', '/'))
+            file_el = mm.File(
+                ID="fid{}-{}".format(file_no, rep_no),
+                ADMID="fid{}-{}-amd".format(file_no, rep_no),
+            )
+            flocat = mm.FLocat(
+                LOCTYPE="URL", href=item["fileOriginalPath"].replace("\\", "/")
+            )
             file_el.append(flocat)
             filegrp.append(file_el)
             file_no += 1
@@ -537,12 +567,11 @@ def _recursively_build_divs(div, pathlist, rep_no, file_no, json_doc):
         _recursively_build_divs(newdiv, pathlist[1:], rep_no, file_no, json_doc)
     else:
         if len(pathlist) == 1:
-            if 'label' in rep_dict.keys():
-                label = rep_dict['label']
+            if "label" in rep_dict.keys():
+                label = rep_dict["label"]
             else:
-                label = os.path.splitext(rep_dict['fileOriginalName'])[0]
-            newdiv = mm.Div(LABEL="{}".format(label),
-                            TYPE="FILE")
+                label = os.path.splitext(rep_dict["fileOriginalName"])[0]
+            newdiv = mm.Div(LABEL="{}".format(label), TYPE="FILE")
             fptr = mm.Fptr(FILEID="fid{}-{}".format(file_no, rep_no))
             newdiv.append(fptr)
             div.append(newdiv)
@@ -560,7 +589,7 @@ def _parse_json_for_structmap(div, rep_no, json_doc):
     file_no = 0
     for item in rep_dict:
         file_no += 1
-        pathlist = os.path.normpath(item['fileOriginalPath']).split(os.path.sep)
+        pathlist = os.path.normpath(item["fileOriginalPath"]).split(os.path.sep)
         # This above may rely on the OS running the script to be the
         # same type that made the path. Not sure on this, but it sounds like
         # a good unit test case...
@@ -568,13 +597,20 @@ def _parse_json_for_structmap(div, rep_no, json_doc):
 
 
 def _build_rep_amdsec(mets, rep_no, digital_original, preservation_type):
-    rep_amdsec = ET.Element("{http://www.loc.gov/METS/}amdSec", ID="rep{}-amd".format(rep_no))
-    general_rep_characteristics = [{'RevisionNumber': '1',
-            'DigitalOriginal': str(digital_original).lower(),
-            'usageType': 'VIEW',
-            'preservationType': preservation_type}]
+    rep_amdsec = ET.Element(
+        "{http://www.loc.gov/METS/}amdSec", ID="rep{}-amd".format(rep_no)
+    )
+    general_rep_characteristics = [
+        {
+            "RevisionNumber": "1",
+            "DigitalOriginal": str(digital_original).lower(),
+            "usageType": "VIEW",
+            "preservationType": preservation_type,
+        }
+    ]
     rep_amd_tech = dnx_factory.build_rep_amdTech(
-        generalRepCharacteristics=general_rep_characteristics)
+        generalRepCharacteristics=general_rep_characteristics
+    )
     rep_amd_rights = None
     rep_amd_digiprov = None
     rep_amd_source = None
@@ -583,7 +619,8 @@ def _build_rep_amdsec(mets, rep_no, digital_original, preservation_type):
         tech_sec=rep_amd_tech,
         rights_sec=rep_amd_rights,
         source_sec=rep_amd_source,
-        digiprov_sec=rep_amd_digiprov)
+        digiprov_sec=rep_amd_digiprov,
+    )
     mets.append(rep_amdsec)
 
 
@@ -593,23 +630,24 @@ def _check_structmaps(mets, structmap_type):
         # Grab top div label if exists
         top_div_label = None
         top_div = structmap.find("./{http://www.loc.gov/METS/}div")
-        if 'LABEL' in top_div.attrib:
-            top_div_label = top_div.attrib['LABEL']
+        if "LABEL" in top_div.attrib:
+            top_div_label = top_div.attrib["LABEL"]
         # jump down to the second layer of divs (usually the
         # 'table of contents' div)
-        toc_div = structmap.find("./{http://www.loc.gov/METS/}div/" +
-                                 "{http://www.loc.gov/METS/}div")
+        toc_div = structmap.find(
+            "./{http://www.loc.gov/METS/}div/" + "{http://www.loc.gov/METS/}div"
+        )
         # check if there are two or more divs below this
         double_divs = structmap.findall(
-            "{http://www.loc.gov/METS/}div/{http://www.loc.gov/METS/}div")
+            "{http://www.loc.gov/METS/}div/{http://www.loc.gov/METS/}div"
+        )
         if len(double_divs) > 0:
-            if structmap_type.upper() not in ['PHYSICAL', 'BOTH']:
+            if structmap_type.upper() not in ["PHYSICAL", "BOTH"]:
                 # This violates Rosetta's rules about structmap types,
                 # So let's make it logical
-                structmap.attrib['TYPE'] = 'LOGICAL'
-            elif structmap_type.upper() in ['PHYSICAL', 'BOTH']:
-                new_sm = mm.StructMap(ID=structmap.attrib['ID'],
-                                      TYPE="PHYSICAL")
+                structmap.attrib["TYPE"] = "LOGICAL"
+            elif structmap_type.upper() in ["PHYSICAL", "BOTH"]:
+                new_sm = mm.StructMap(ID=structmap.attrib["ID"], TYPE="PHYSICAL")
 
                 div_1 = mm.Div(LABEL=top_div_label)
                 new_sm.append(div_1)
@@ -618,49 +656,54 @@ def _check_structmaps(mets, structmap_type):
                 div_1.append(div_2)
 
                 file_divs = structmap.findall(
-                    './/{http://www.loc.gov/METS/}div[@TYPE="FILE"]')
+                    './/{http://www.loc.gov/METS/}div[@TYPE="FILE"]'
+                )
                 for file_div in file_divs:
                     div_2.append(deepcopy(file_div))
                 mets.append(new_sm)
-                if structmap_type.upper() == 'PHYSICAL':
+                if structmap_type.upper() == "PHYSICAL":
                     mets.remove(structmap)
                 else:
-                    structmap.attrib['TYPE'] = 'LOGICAL'
+                    structmap.attrib["TYPE"] = "LOGICAL"
     return mets
 
 
 def whittle_down_div(file_div):
     print(file_div)
-    if ('LABEL' in file_div.attrib) and (file_div.attrib['LABEL'] == 'FILE'):
+    if ("LABEL" in file_div.attrib) and (file_div.attrib["LABEL"] == "FILE"):
         return file_div
     else:
         return whittle_down_div(file_div.find("{http://www.loc.gov/METS/}div"))
 
 
-def build_mets_from_json(ie_dmd_dict=None,
-                pres_master_json=None,
-                modified_master_json=None,
-                access_derivative_json=None,
-                cms=None,
-                webHarvesting=None,
-                generalIECharacteristics=None,
-                objectIdentifier=None,
-                accessRightsPolicy=None,
-                eventList=None,
-                input_dir=None,
-                digital_original=False,
-                structmap_type="DEFAULT"):
+def build_mets_from_json(
+    ie_dmd_dict=None,
+    pres_master_json=None,
+    modified_master_json=None,
+    access_derivative_json=None,
+    cms=None,
+    webHarvesting=None,
+    generalIECharacteristics=None,
+    objectIdentifier=None,
+    accessRightsPolicy=None,
+    eventList=None,
+    input_dir=None,
+    digital_original=False,
+    structmap_type="DEFAULT",
+):
     """Build a METS XML file using JSON-formatted data describing the
     rep structures, rather than directory paths."""
     mets = mf.build_mets()
-    _build_ie_dmd_amd(mets,
+    _build_ie_dmd_amd(
+        mets,
         ie_dmd_dict=ie_dmd_dict,
         generalIECharacteristics=generalIECharacteristics,
         cms=cms,
         webHarvesting=webHarvesting,
         objectIdentifier=objectIdentifier,
         accessRightsPolicy=accessRightsPolicy,
-        eventList=eventList)
+        eventList=eventList,
+    )
 
     # start building fileSec here, but do not append it until after all
     # the amdSecs have been added.
@@ -670,27 +713,27 @@ def build_mets_from_json(ie_dmd_dict=None,
     # the fileSec has been added.
     structmap_list = []
 
-
     rep_no = 1
     if pres_master_json != None:
         pmd = json.loads(pres_master_json)
         pm_rep_no = rep_no
 
         # Build rep AMD Sec
-        _build_rep_amdsec(mets, rep_no, digital_original, 'PRESERVATION_MASTER')
+        _build_rep_amdsec(mets, rep_no, digital_original, "PRESERVATION_MASTER")
         # run through json structure and find files, assembling their
         # filepaths along the way
         _parse_json_for_fl_amd(mets, rep_no, pres_master_json)
         # construct fileSec details for rep
-        filegrp = mm.FileGrp(ID="rep{}".format(rep_no),
-                    ADMID="rep{}-amd".format(rep_no))
+        filegrp = mm.FileGrp(
+            ID="rep{}".format(rep_no), ADMID="rep{}-amd".format(rep_no)
+        )
         _parse_json_for_filegrp(filegrp, rep_no, pres_master_json, input_dir)
         filesec.append(filegrp)
         # Build the structmap for this rep
         structmap = mm.StructMap(ID="rep{}-1".format(rep_no), TYPE="PHYSICAL")
-        div1 = mm.Div(LABEL='Preservation Master')
+        div1 = mm.Div(LABEL="Preservation Master")
         structmap.append(div1)
-        div2 = mm.Div(LABEL='Table of Contents')
+        div2 = mm.Div(LABEL="Table of Contents")
         div1.append(div2)
         mets.append(structmap)
         _parse_json_for_structmap(div2, rep_no, pres_master_json)
@@ -699,18 +742,19 @@ def build_mets_from_json(ie_dmd_dict=None,
     if modified_master_json != None:
         mm_rep_no = rep_no
         mmd = json.loads(modified_master_json)
-        _build_rep_amdsec(mets, rep_no, digital_original, 'MODIFIED_MASTER')
+        _build_rep_amdsec(mets, rep_no, digital_original, "MODIFIED_MASTER")
         _parse_json_for_fl_amd(mets, rep_no, modified_master_json)
         # construct fileSec details for rep
-        filegrp = mm.FileGrp(ID="rep{}".format(rep_no),
-                    ADMID="rep{}-amd".format(rep_no))
+        filegrp = mm.FileGrp(
+            ID="rep{}".format(rep_no), ADMID="rep{}-amd".format(rep_no)
+        )
         _parse_json_for_filegrp(filegrp, rep_no, modified_master_json, input_dir)
         filesec.append(filegrp)
         # Build the structmap for this rep
         structmap = mm.StructMap(ID="rep{}-1".format(rep_no), TYPE="PHYSICAL")
-        div1 = mm.Div(LABEL='Modified Master')
+        div1 = mm.Div(LABEL="Modified Master")
         structmap.append(div1)
-        div2 = mm.Div(LABEL='Table of Contents')
+        div2 = mm.Div(LABEL="Table of Contents")
         div1.append(div2)
         mets.append(structmap)
         _parse_json_for_structmap(div2, rep_no, modified_master_json)
@@ -719,18 +763,19 @@ def build_mets_from_json(ie_dmd_dict=None,
     if access_derivative_json != None:
         add = json.loads(access_derivative_json)
         ad_rep_no = rep_no
-        _build_rep_amdsec(mets, rep_no, digital_original, 'DERIVATIVE_COPY')
+        _build_rep_amdsec(mets, rep_no, digital_original, "DERIVATIVE_COPY")
         _parse_json_for_fl_amd(mets, rep_no, access_derivative_json)
         # construct fileSec details for rep
-        filegrp = mm.FileGrp(ID="rep{}".format(rep_no),
-                    ADMID="rep{}-amd".format(rep_no))
+        filegrp = mm.FileGrp(
+            ID="rep{}".format(rep_no), ADMID="rep{}-amd".format(rep_no)
+        )
         _parse_json_for_filegrp(filegrp, rep_no, access_derivative_json, input_dir)
         filesec.append(filegrp)
         # Build the structmap for this rep
         structmap = mm.StructMap(ID="rep{}-1".format(rep_no), TYPE="PHYSICAL")
-        div1 = mm.Div(LABEL='Access Derivative')
+        div1 = mm.Div(LABEL="Access Derivative")
         structmap.append(div1)
-        div2 = mm.Div(LABEL='Table of Contents')
+        div2 = mm.Div(LABEL="Table of Contents")
         div1.append(div2)
         mets.append(structmap)
         _parse_json_for_structmap(div2, ad_rep_no, access_derivative_json)

--- a/mets_dnx/factory.py
+++ b/mets_dnx/factory.py
@@ -258,8 +258,8 @@ def build_mets(
                 {
                     # 'fileOriginalPath': file_original_location,
                     "fileSizeBytes": str(file_size_bytes),
-                    "fileModificationDate": last_modified,
-                    "fileCreationDate": created_time,
+                    # 'fileModificationDate': last_modified,
+                    # 'fileCreationDate': created_time,
                     "fileOriginalName": file_original_name,
                     "label": file_label,
                     "fileMIMEType": "text/plain",
@@ -290,11 +290,23 @@ def build_mets(
             "rep([0-9]+)\-file([0-9]+)", r"fid\2-\1", element.attrib["ID"]
         )
     for element in mets.xpath(".//*[@ADMID]"):
+        # element.attrib['ADMID'] = re.sub(
+        #         'ie[0-9]+\-rep([0-9]+)\-file([0-9]+)-amd',
+        #         r'fid\2-\1-amd',
+        #         element.attrib['ADMID'])
+        # element.attrib['ADMID'] = re.sub(
+        #         'ie[0-9]+\-rep([0-9]+)-amd',
+        #         r'rep\1-amd',
+        #         element.attrib['ADMID'])
         element.attrib["ADMID"] = re.sub("ie[0-9]+\-", "", element.attrib["ADMID"])
         element.attrib["ADMID"] = re.sub(
             "rep([0-9]+)\-file([0-9]+)", r"fid\2-\1", element.attrib["ADMID"]
         )
     for element in mets.xpath(".//*[@FILEID]"):
+        # element.attrib['FILEID'] = re.sub(
+        #         'ie[0-9]+\-rep([0-9])+\-file([0-9]+)',
+        #         r'fid\2-\1',
+        #         element.attrib['FILEID'])
         element.attrib["FILEID"] = re.sub("ie[0-9]+\-", "", element.attrib["FILEID"])
         element.attrib["FILEID"] = re.sub(
             "rep([0-9]+)\-file([0-9]+)", r"fid\2-\1", element.attrib["FILEID"]
@@ -330,7 +342,8 @@ def build_mets(
                 './/{http://www.loc.gov/METS/}div[@TYPE="FILE"]'
             )
             for file_div in file_divs:
-                file_div.attrib["LABEL"] = os.path.splitext(file_div.attrib["LABEL"])[0]
+                # file_div.attrib["LABEL"] = os.path.splitext(file_div.attrib["LABEL"])[0]
+                file_div.attrib["LABEL"] = file_div.attrib["LABEL"].split(".")[0]
 
     mets = _check_structmaps(mets, structmap_type)
     return mets

--- a/mets_dnx/factory.py
+++ b/mets_dnx/factory.py
@@ -37,16 +37,21 @@ def build_amdsec(amdsec, tech_sec=None, rights_sec=None,
                     amdsec,
                     "{http://www.loc.gov/METS/}rightsMD",
                     ID=amd_id + "-rights")
-    amd_source = ET.SubElement(
-                    amdsec,
-                    "{http://www.loc.gov/METS/}sourceMD",
-                    ID=amd_id + "-source")
+    if source_sec != None:
+        amd_source = ET.SubElement(
+                        amdsec,
+                        "{http://www.loc.gov/METS/}sourceMD",
+                        ID=amd_id + "-source")
     amd_digiprov = ET.SubElement(
                     amdsec,
                     "{http://www.loc.gov/METS/}digiprovMD",
                     ID=amd_id + "-digiprov")
-
-    for el in [amd_tech, amd_rights, amd_source, amd_digiprov]:
+    
+    if source_sec == None:
+        el_list = [amd_tech, amd_rights, amd_digiprov]
+    else:
+        el_list = [amd_tech, amd_rights, amd_source, amd_digiprov]
+    for el in el_list:
         mdWrap = ET.SubElement(
                         el,
                         "{http://www.loc.gov/METS/}mdWrap",
@@ -71,10 +76,10 @@ def build_amdsec(amdsec, tech_sec=None, rights_sec=None,
         if (el.tag == "{http://www.loc.gov/METS/}sourceMD" and
                 source_sec != None):
             xmlData.append(source_sec)
-        elif (el.tag == "{http://www.loc.gov/METS/}sourceMD" and
-                source_sec == None):
-            xmlData.append(ET.Element("dnx",
-                xmlns="http://www.exlibrisgroup.com/dps/dnx"))
+        # elif (el.tag == "{http://www.loc.gov/METS/}sourceMD" and
+        #         source_sec == None):
+        #     xmlData.append(ET.Element("dnx",
+        #         xmlns="http://www.exlibrisgroup.com/dps/dnx"))
 
         if (el.tag == "{http://www.loc.gov/METS/}digiprovMD" and
                 digiprov_sec != None):
@@ -159,7 +164,8 @@ def build_mets(ie_dmd_dict=None,
                 eventList=None,
                 input_dir=None,
                 digital_original=False,
-                structmap_type='DEFAULT'):
+                structmap_type='DEFAULT', 
+                exclude_file_characteristics = []):
 
     mets = mf.build_mets()
 
@@ -206,7 +212,7 @@ def build_mets(ie_dmd_dict=None,
 
         rep_amdsec = mets.xpath("//mets:amdSec[@ID='%s']" %
                 str(rep_id + '-amd'), namespaces=mets.nsmap)[0]
-        general_rep_characteristics = [{'RevisionNumber': '1',
+        general_rep_characteristics = [{#'RevisionNumber': '1',
                 'DigitalOriginal': str(digital_original).lower(),
                 'usageType': 'VIEW',
                 'preservationType': pres_type}]
@@ -241,12 +247,17 @@ def build_mets(ie_dmd_dict=None,
                     "%Y-%m-%dT%H:%M:%S",
                     time.localtime(os.path.getctime(file_original_location)))
             general_file_characteristics = [{
-                'fileOriginalPath': file_original_location,
+                # 'fileOriginalPath': file_original_location,
                 'fileSizeBytes': str(file_size_bytes),
-                'fileModificationDate': last_modified,
-                'fileCreationDate': created_time,
+                # 'fileModificationDate': last_modified,
+                # 'fileCreationDate': created_time,
                 'fileOriginalName': file_original_name,
-                'label': file_label}]
+                'label': file_label,
+                'fileMIMEType': "text/plain",}]
+            if exclude_file_characteristics!=[]:
+                for file_characteristics in exclude_file_characteristics:
+                    if file_characteristics in general_file_characteristics[0].keys():
+                        general_file_characteristics[0].pop(file_characteristics)
 
             file_fixity =  [{
                 'fixityType': 'MD5',
@@ -322,7 +333,8 @@ def build_single_file_mets(ie_dmd_dict=None,
                 objectIdentifier=None,
                 accessRightsPolicy=None,
                 eventList=None,
-                digital_original=False):
+                digital_original=False,
+                exclude_file_characteristics = []):
     mets = mf.build_mets()
     _build_ie_dmd_amd(mets,
             ie_dmd_dict=ie_dmd_dict,
@@ -371,7 +383,10 @@ def build_single_file_mets(ie_dmd_dict=None,
         'fileCreationDate': created_time,
         'fileOriginalName': file_original_name,
         'label': file_label}]
-
+    if exclude_file_characteristics!=[]:
+        for file_characteristics in exclude_file_characteristics:
+            if file_characteristics in general_file_characteristics[0].keys():
+                general_file_characteristics[0].pop(file_characteristics)
     file_fixity =  [{
         'fixityType': 'MD5',
         'fixityValue': generate_md5(file_original_location)}]

--- a/mets_dnx/factory.py
+++ b/mets_dnx/factory.py
@@ -290,17 +290,14 @@ def build_mets(
             "rep([0-9]+)\-file([0-9]+)", r"fid\2-\1", element.attrib["ID"]
         )
     for element in mets.xpath(".//*[@ADMID]"):
+        element.attrib["ADMID"] = re.sub("ie[0-9]+\-", "", element.attrib["ADMID"])
         element.attrib["ADMID"] = re.sub(
-            "ie[0-9]+\-rep([0-9]+)\-file([0-9]+)-amd",
-            r"fid\2-\1-amd",
-            element.attrib["ADMID"],
-        )
-        element.attrib["ADMID"] = re.sub(
-            "ie[0-9]+\-rep([0-9]+)-amd", r"rep\1-amd", element.attrib["ADMID"]
+            "rep([0-9]+)\-file([0-9]+)", r"fid\2-\1", element.attrib["ADMID"]
         )
     for element in mets.xpath(".//*[@FILEID]"):
+        element.attrib["FILEID"] = re.sub("ie[0-9]+\-", "", element.attrib["FILEID"])
         element.attrib["FILEID"] = re.sub(
-            "ie[0-9]+\-rep([0-9])+\-file([0-9]+)", r"fid\2-\1", element.attrib["FILEID"]
+            "rep([0-9]+)\-file([0-9]+)", r"fid\2-\1", element.attrib["FILEID"]
         )
 
     # 2017-02-16 (SM): Modify the file label in the structmaps so that it does


### PR DESCRIPTION
Found a bug in the **_build_ie_dmd_amd** function that pass wrong variables to **build_amdsec** function. Fix this bug by explicitly passing the related variables.